### PR TITLE
update readme + maxsize 255

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/RobTillaart/RunningMedian/blob/master/LICENSE)
 [![GitHub release](https://img.shields.io/github/release/RobTillaart/RunningMedian.svg?maxAge=3600)](https://github.com/RobTillaart/RunningMedian/releases)
 
+
 # RunningMedian
 
 Arduino library to determine the running median by means of a circular buffer.
+
 
 ## Description
 
@@ -33,6 +35,8 @@ and is currently set to 19. This value is reasonable for most applications.
 This define can be changed in the .h file or overruled compiletime.
 Be aware that the library will consume more memory as it allocates 
 **MEDIAN_MAX_SIZE** elements internally.
+
+With version 0.3.1 the size can be set to 255.
 
 
 ## Interface

--- a/README.md
+++ b/README.md
@@ -13,30 +13,32 @@ Arduino library to determine the running median by means of a circular buffer.
 
 Running Median looks like a running average with a small but important twist.
 Running average averages the last N samples while the running median takes 
-the last N samples, sort them and take the middle one, or the average of the middle two.
+the last N samples, sort them and take the middle one, or the average of the 
+middle two in case the internal buffer size is even.
 
 Important differences between running average and running median:
 - Running median will return real data (e.g. a real sample from a sensor) 
-if one uses an odd size of the buffer (preferred).
+if one uses an odd size of the buffer (therefor preferred).
 Running average may return a value that is never sampled.
 - Running median will give zero weight to outliers, and 100% to the middle sample, 
 whereas running average gives the same weight to all samples.
 - Running median will give often constant values for some time.
-- As one knows the values in the buffer one can predict to some extend how much 
-the next samples will change the running median. 
-- Running median is a bit harder as one needs to keep the values in order 
+- As one knows the values in the buffer one can predict the maximum change of 
+the running median in the next steps in advance.
+- Running median is slower as one needs to keep the values in timed order 
 to remove the oldest and keep them sorted to be able to select the median.
 
 
 #### Note MEDIAN_MAX_SIZE
 
-The maxsize of the internal buffer is defined by **MEDIAN_MAX_SIZE** 
-and is currently set to 19. This value is reasonable for most applications.
-This define can be changed in the .h file or overruled compiletime.
-Be aware that the library will consume more memory as it allocates 
-**MEDIAN_MAX_SIZE** elements internally.
+The maximum size of the internal buffer is defined by **MEDIAN_MAX_SIZE** and is 
+set to 255 (since version 0.3.1). The memory allocated currently is in the order
+of 5 bytes per element plus some overhead, so 255 elements take ~1300 bytes.
+For an UNO this is quite a bit.
 
-With version 0.3.1 the size can be set to 255.
+With larger sizes the performance penalty to keep the internal array sorted 
+is large. For most applications a value much lower e.g. 19 is working well, and 
+is performance wise O(100x) faster in sorting than 255 elements.
 
 
 ## Interface
@@ -44,28 +46,31 @@ With version 0.3.1 the size can be set to 255.
 
 ### Constructor
 
-- **RunningMedian(const uint8_t size)** Constructor
-- **~RunningMedian()** 
+- **RunningMedian(const uint8_t size)** Constructor, dynamically allocates memory.
+- **~RunningMedian()** Destructor
 - **uint8_t getSize()** returns size of internal array
 - **uint8_t getCount()** returns current used elements, getCount() <= getSize()
+- **bool isFull()** returns true if the internal buffer is 100% filled.
 
 
 ### Base functions
 
-- **clear()** resets internal buffer and var
-- **add(const float value) ** adds a new value to internal buffer, optionally replacing the oldest element.
+- **clear()** resets internal buffer and variables, effectively emptird thr buffer.
+- **add(const float value) ** adds a new value to internal buffer, optionally replacing the oldest element if the buffer is full
 - **float getMedian()** returns the median == middle element
-- **float getAverage()** returns average of the values in the internal buffer
-- **float getAverage(uint8_t nMedian)** returns average of the middle nMedian values, removes noise from outliers
-- **float getHighest()** idem
-- **float getLowest()** idem
-- **float getQuantile(const float q)** returns the Quantile
+- **float getAverage()** returns average of **all** the values in the internal buffer
+- **float getAverage(uint8_t nMedian)** returns average of **the middle n** values. 
+This effectively removes noise from the outliers in the samples.
+- **float getHighest()** get the largest values in the buffer.
+- **float getLowest()** get the smallest value in the buffer.
+- **float getQuantile(const float q)** returns the Quantile value from the buffer. 
+This value is often interpolated.
 
 
 ### Less used functions
 
-- **float getElement(const uint8_t n)** returns the n'th element from the values in time order
-- **float getSortedElement(const uint8_t n)** returns the n'th element from the values in size order (ascending)
+- **float getElement(const uint8_t n)** returns the n'th element from the values in time order.
+- **float getSortedElement(const uint8_t n)** returns the n'th element from the values in size order (sorted ascending)
 - **float predict(const uint8_t n)** predict the max change of median after n additions, n should be smaller than **getSize()/2**
 
 

--- a/RunningMedian.cpp
+++ b/RunningMedian.cpp
@@ -1,7 +1,7 @@
 //
 //    FILE: RunningMedian.cpp
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.3.0
+// VERSION: 0.3.1
 // PURPOSE: RunningMedian library for Arduino
 //
 //  HISTORY:
@@ -25,6 +25,7 @@
 //  0.2.1   2020-06-19  fix library.json
 //  0.2.2   2021-01-03  add Arduino-CI + unit tests
 //  0.3.0   2021-01-04  malloc memory as default storage
+//  0.3.1   2021-01-16  Changed size parameter to 255 max
 
 
 #include "RunningMedian.h"
@@ -32,7 +33,10 @@
 
 RunningMedian::RunningMedian(const uint8_t size)
 {
-  _size = constrain(size, MEDIAN_MIN_SIZE, MEDIAN_MAX_SIZE);
+  _size = size;
+  if (_size < MEDIAN_MIN_SIZE) _size = MEDIAN_MIN_SIZE;
+  // if (_size > MEDIAN_MAX_SIZE) _size = MEDIAN_MAX_SIZE;
+
 #ifdef RUNNING_MEDIAN_USE_MALLOC
   _values = (float *) malloc(_size * sizeof(float));
   _sortIdx  = (uint8_t *) malloc(_size * sizeof(uint8_t));

--- a/RunningMedian.h
+++ b/RunningMedian.h
@@ -3,7 +3,7 @@
 //    FILE: RunningMedian.h
 //  AUTHOR: Rob Tillaart
 // PURPOSE: RunningMedian library for Arduino
-// VERSION: 0.3.0
+// VERSION: 0.3.1
 //     URL: https://github.com/RobTillaart/RunningMedian
 //     URL: http://arduino.cc/playground/Main/RunningMedian
 // HISTORY: See RunningMedian.cpp
@@ -12,7 +12,7 @@
 
 #include "Arduino.h"
 
-#define RUNNING_MEDIAN_VERSION        (F("0.3.0"))
+#define RUNNING_MEDIAN_VERSION        (F("0.3.1"))
 
 
 // fall back to fixed storage for dynamic version => remove true
@@ -25,7 +25,7 @@
 
 #ifdef RUNNING_MEDIAN_USE_MALLOC
 // max 250 to not overflow uint8_t internal vars
-#define MEDIAN_MAX_SIZE               250
+#define MEDIAN_MAX_SIZE               255
 #else
 // using fixed memory will be limited to 19 elements.
 #define MEDIAN_MAX_SIZE               19
@@ -76,6 +76,7 @@ protected:
   uint8_t   _size;      // max number of values
   uint8_t   _count;     // current number of values
   uint8_t   _index;     // next index to add.
+
 
   // _values holds the elements themself
   // _p  holds the index for sorted 

--- a/RunningMedian.h
+++ b/RunningMedian.h
@@ -69,6 +69,7 @@ public:
   uint8_t getSize()    { return _size; };
   // returns current used elements, getCount() <= getSize()
   uint8_t getCount()   { return _count; };
+  bool    isFull()     { return (_count == _size); }
 
 
 protected:

--- a/examples/RunningMedian_large/RunningMedian_large.ino
+++ b/examples/RunningMedian_large/RunningMedian_large.ino
@@ -56,7 +56,7 @@ void loop()
   if (count == 255)
   {
     count++;
-    for (int i = 0; i < 255; i++}
+    for (int i = 0; i < 255; i++)
     {
       Serial.println(samples.getElement(i));
     }

--- a/examples/RunningMedian_large/RunningMedian_large.ino
+++ b/examples/RunningMedian_large/RunningMedian_large.ino
@@ -1,7 +1,7 @@
 //
-//    FILE: RunningMedian2.ino
-//  AUTHOR: Rob Tillaart ( kudos to Sembazuru)
-// VERSION: 0.1.2
+//    FILE: RunningMedian_large.ino
+//  AUTHOR: Rob Tillaart
+// VERSION: 0.1.3
 // PURPOSE: demo most functions
 //    DATE: 2013-10-17
 //     URL: https://github.com/RobTillaart/RunningMedian
@@ -9,9 +9,14 @@
 
 #include "RunningMedian.h"
 
-RunningMedian samples = RunningMedian(101);
+
+RunningMedian samples = RunningMedian(255);
+
 
 long count = 0;
+
+uint32_t start, dur1, dur2, dur3;
+
 
 void setup()
 {
@@ -22,6 +27,40 @@ void setup()
   Serial.println(samples.getSize());
 }
 
+
 void loop()
 {
+  if (count <255)
+  {
+    start = micros();
+    samples.add(count);
+    dur1 = micros() - start;
+    start = micros();
+    count = samples.getCount();
+    dur2 = micros() - start;
+    start = micros();
+    float value = samples.getMedian();
+    dur3 = micros() - start;
+    
+    Serial.print(count);
+    Serial.print('\t');
+    Serial.print(dur1);
+    Serial.print('\t');
+    Serial.print(dur2);
+    Serial.print('\t');
+    Serial.print(dur3);
+    Serial.print('\t');
+    Serial.println();
+  }
+
+  if (count == 255)
+  {
+    count++;
+    for (int i = 0; i < 255; i++}
+    {
+      Serial.println(samples.getElement(i));
+    }
+  }
 }
+
+// -- END OF FILE --

--- a/library.json
+++ b/library.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "https://github.com/RobTillaart/RunningMedian.git"
   },
-  "version":"0.3.0",
+  "version":"0.3.1",
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=RunningMedian
-version=0.3.0
+version=0.3.1
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=The library stores the last N individual values in a buffer to select the median.

--- a/test/unit_test_001.cpp
+++ b/test/unit_test_001.cpp
@@ -31,10 +31,6 @@
 
 #include <ArduinoUnitTests.h>
 
-#define assertEqualFloat(arg1, arg2, arg3)  assertOp("assertEqualFloat", "expected", fabs(arg1 - arg2), compareLessOrEqual, "<=", "actual", arg3)
-// #define assertEqualINF(arg)  assertOp("assertEqualINF", "expected", INFINITY, compareEqual, "==", "actual", arg)
-// #define assertEqualNAN(arg)  assertOp("assertEqualNAN", "expected", true, compareEqual, "==", "actual", isnan(arg))
-
 
 #include "Arduino.h"
 #include "RunningMedian.h"


### PR DESCRIPTION
- dynamically allocate memory allowing max size of 255 elements. (consequence much slower, so use with care)
- add **bool isFull()** 
- updated example to show performance degradation with large internal buffer.